### PR TITLE
flush transfer lockOwner

### DIFF
--- a/api.go
+++ b/api.go
@@ -53,7 +53,7 @@ type FileSystem interface {
 	Write(ctx *Context, path string, uFh uint32, data []byte, off uint64) (written uint32, code fuse.Status)
 	Fallocate(ctx *Context, path string, uFh uint32, off uint64, size uint64, mode uint32) fuse.Status
 	Fsync(ctx *Context, path string, uFh uint32, flags uint32) fuse.Status
-	Flush(ctx *Context, path string, uFh uint32) fuse.Status
+	Flush(ctx *Context, path string, uFh uint32, lockOwner uint64) fuse.Status
 	Release(ctx *Context, path string, uFh uint32)
 
 	GetLk(ctx *Context, path string, uFh uint32, owner uint64, lk *fuse.FileLock, flags uint32, out *fuse.FileLock) fuse.Status

--- a/bridge.go
+++ b/bridge.go
@@ -523,7 +523,7 @@ func (b *rawBridge) Flush(cancel <-chan struct{}, input *fuse.FlushIn) fuse.Stat
 	n, f := b.inodeAndFile(input.NodeId, uint32(input.Fh), ctx)
 	path := b.fpathOf(n, f)
 
-	return b.fs.Flush(ctx, path, f.uFh)
+	return b.fs.Flush(ctx, path, f.uFh, input.LockOwner)
 }
 
 func (b *rawBridge) Release(cancel <-chan struct{}, input *fuse.ReleaseIn) {

--- a/default.go
+++ b/default.go
@@ -89,7 +89,7 @@ func (fs defaultFileSystem) Fallocate(ctx *Context, path string, uFh uint32, off
 func (fs defaultFileSystem) Fsync(ctx *Context, path string, uFh uint32, flags uint32) fuse.Status {
 	return fuse.ENOSYS
 }
-func (fs defaultFileSystem) Flush(ctx *Context, path string, uFh uint32) fuse.Status {
+func (fs defaultFileSystem) Flush(ctx *Context, path string, uFh uint32, lockOwner uint64) fuse.Status {
 	return fuse.ENOSYS
 }
 func (fs defaultFileSystem) Release(ctx *Context, path string, uFh uint32) {}


### PR DESCRIPTION
fcntl的传统记录锁需要在文件flush时通过此参数解锁